### PR TITLE
Detect rate limiting from gtm api, back off and retry

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ provider "gtm" {
   account_id                 = "6105084028"
   container_id               = "119458552"
   workspace_name             = "my-workspace"
-  max_api_queries_per_minute = 15
+  retry_limit                = 10
 }
 ```
 
@@ -34,4 +34,4 @@ provider "gtm" {
 
 ### Optional
 
-- `max_api_queries_per_minute` (Number) Maximum number of API queries per minute.
+- `retry_limit` (Number) Number of times to retry requests when rate-limited before giving up.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -12,7 +12,7 @@ provider "gtm" {
   account_id                 = "6105084028"
   container_id               = "119458552"
   workspace_name             = "my-workspace"
-  max_api_queries_per_minute = 15
+  retry_limitalias           = 10
 }
 
 resource "gtm_variable" "test_variable" {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,5 +3,5 @@ provider "gtm" {
   account_id                 = "6105084028"
   container_id               = "119458552"
   workspace_name             = "my-workspace"
-  max_api_queries_per_minute = 15
+  retry_limit                = 10
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"google.golang.org/api/googleapi"
@@ -11,10 +12,10 @@ import (
 )
 
 type ClientOptions struct {
-	CredentialFile             string
-	AccountId                  string
-	ContainerId                string
-	WaitingTimeBeforeEachQuery time.Duration
+	CredentialFile string
+	AccountId      string
+	ContainerId    string
+	RetryLimit     int
 }
 
 type Client struct {
@@ -39,20 +40,14 @@ func (c *Client) containerPath() string {
 	return "accounts/" + opts.AccountId + "/containers/" + opts.ContainerId
 }
 
-func (c *Client) beforeEachQuery() {
-	time.Sleep(c.Options.WaitingTimeBeforeEachQuery)
-}
-
 var ErrNotExist = errors.New("not exist")
 
 func (c *Client) CreateWorkspace(ws *tagmanager.Workspace) (*tagmanager.Workspace, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Create(c.containerPath(), ws).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Create(c.containerPath(), ws).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) ListWorkspaces() ([]*tagmanager.Workspace, error) {
-	c.beforeEachQuery()
-	resp, err := c.Accounts.Containers.Workspaces.List(c.containerPath()).Do()
+	resp, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.List(c.containerPath()).Do, c.Options.RetryLimit)
 	if err != nil {
 		return nil, err
 	} else {
@@ -61,9 +56,7 @@ func (c *Client) ListWorkspaces() ([]*tagmanager.Workspace, error) {
 }
 
 func (c *Client) Workspace(id string) (*tagmanager.Workspace, error) {
-	c.beforeEachQuery()
-	ws, err := c.Accounts.Containers.Workspaces.Get(c.containerPath() + "/workspaces/" + id).Do()
-
+	ws, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Get(c.containerPath()+"/workspaces/"+id).Do, c.Options.RetryLimit)
 	if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 404 {
 		return nil, ErrNotExist
 	} else {
@@ -72,13 +65,11 @@ func (c *Client) Workspace(id string) (*tagmanager.Workspace, error) {
 }
 
 func (c *Client) UpdateWorkspaces(id string, ws *tagmanager.Workspace) (*tagmanager.Workspace, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Update(c.containerPath()+"/workspaces/"+id, ws).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Update(c.containerPath()+"/workspaces/"+id, ws).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) DeleteWorkspace(id string) error {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Delete(c.containerPath() + "/workspaces/" + id).Do()
+	return executeWithRetry(c.Accounts.Containers.Workspaces.Delete(c.containerPath()+"/workspaces/"+id).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) workspacePath(id string) string {
@@ -86,13 +77,11 @@ func (c *Client) workspacePath(id string) string {
 }
 
 func (c *Client) CreateTag(workspaceId string, tag *tagmanager.Tag) (*tagmanager.Tag, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Tags.Create(c.workspacePath(workspaceId), tag).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Tags.Create(c.workspacePath(workspaceId), tag).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) ListTags(workspaceId string) ([]*tagmanager.Tag, error) {
-	c.beforeEachQuery()
-	resp, err := c.Accounts.Containers.Workspaces.Tags.List(c.workspacePath(workspaceId)).Do()
+	resp, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Tags.List(c.workspacePath(workspaceId)).Do, c.Options.RetryLimit)
 	if err != nil {
 		return nil, err
 	} else {
@@ -101,8 +90,7 @@ func (c *Client) ListTags(workspaceId string) ([]*tagmanager.Tag, error) {
 }
 
 func (c *Client) Tag(workspaceId string, tagId string) (*tagmanager.Tag, error) {
-	c.beforeEachQuery()
-	tag, err := c.Accounts.Containers.Workspaces.Tags.Get(c.workspacePath(workspaceId) + "/tags/" + tagId).Do()
+	tag, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Tags.Get(c.workspacePath(workspaceId)+"/tags/"+tagId).Do, c.Options.RetryLimit)
 
 	if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 404 {
 		return nil, ErrNotExist
@@ -112,23 +100,19 @@ func (c *Client) Tag(workspaceId string, tagId string) (*tagmanager.Tag, error) 
 }
 
 func (c *Client) UpdateTag(workspaceId string, tagId string, tag *tagmanager.Tag) (*tagmanager.Tag, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Tags.Update(c.workspacePath(workspaceId)+"/tags/"+tagId, tag).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Tags.Update(c.workspacePath(workspaceId)+"/tags/"+tagId, tag).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) DeleteTag(workspaceId string, tagId string) error {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Tags.Delete(c.workspacePath(workspaceId) + "/tags/" + tagId).Do()
+	return executeWithRetry(c.Accounts.Containers.Workspaces.Tags.Delete(c.workspacePath(workspaceId)+"/tags/"+tagId).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) CreateVariable(workspaceId string, variable *tagmanager.Variable) (*tagmanager.Variable, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Variables.Create(c.workspacePath(workspaceId), variable).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Variables.Create(c.workspacePath(workspaceId), variable).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) ListVariables(workspaceId string) ([]*tagmanager.Variable, error) {
-	c.beforeEachQuery()
-	resp, err := c.Accounts.Containers.Workspaces.Variables.List(c.workspacePath(workspaceId)).Do()
+	resp, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Variables.List(c.workspacePath(workspaceId)).Do, c.Options.RetryLimit)
 	if err != nil {
 		return nil, err
 	} else {
@@ -137,8 +121,7 @@ func (c *Client) ListVariables(workspaceId string) ([]*tagmanager.Variable, erro
 }
 
 func (c *Client) Variable(workspaceId string, variableId string) (*tagmanager.Variable, error) {
-	c.beforeEachQuery()
-	variable, err := c.Accounts.Containers.Workspaces.Variables.Get(c.workspacePath(workspaceId) + "/variables/" + variableId).Do()
+	variable, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Variables.Get(c.workspacePath(workspaceId)+"/variables/"+variableId).Do, c.Options.RetryLimit)
 
 	if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 404 {
 		return nil, ErrNotExist
@@ -148,23 +131,19 @@ func (c *Client) Variable(workspaceId string, variableId string) (*tagmanager.Va
 }
 
 func (c *Client) UpdateVariable(workspaceId string, variableId string, variable *tagmanager.Variable) (*tagmanager.Variable, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Variables.Update(c.workspacePath(workspaceId)+"/variables/"+variableId, variable).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Variables.Update(c.workspacePath(workspaceId)+"/variables/"+variableId, variable).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) DeleteVariable(workspaceId string, variableId string) error {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Variables.Delete(c.workspacePath(workspaceId) + "/variables/" + variableId).Do()
+	return executeWithRetry(c.Accounts.Containers.Workspaces.Variables.Delete(c.workspacePath(workspaceId)+"/variables/"+variableId).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) CreateTrigger(workspaceId string, trigger *tagmanager.Trigger) (*tagmanager.Trigger, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Triggers.Create(c.workspacePath(workspaceId), trigger).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Triggers.Create(c.workspacePath(workspaceId), trigger).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) ListTriggers(workspaceId string) ([]*tagmanager.Trigger, error) {
-	c.beforeEachQuery()
-	resp, err := c.Accounts.Containers.Workspaces.Triggers.List(c.workspacePath(workspaceId)).Do()
+	resp, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Triggers.List(c.workspacePath(workspaceId)).Do, c.Options.RetryLimit)
 	if err != nil {
 		return nil, err
 	} else {
@@ -173,8 +152,7 @@ func (c *Client) ListTriggers(workspaceId string) ([]*tagmanager.Trigger, error)
 }
 
 func (c *Client) Trigger(workspaceId string, triggerId string) (*tagmanager.Trigger, error) {
-	c.beforeEachQuery()
-	trigger, err := c.Accounts.Containers.Workspaces.Triggers.Get(c.workspacePath(workspaceId) + "/triggers/" + triggerId).Do()
+	trigger, err := getResponseWithRetry(c.Accounts.Containers.Workspaces.Triggers.Get(c.workspacePath(workspaceId)+"/triggers/"+triggerId).Do, c.Options.RetryLimit)
 
 	if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 404 {
 		return nil, ErrNotExist
@@ -184,11 +162,58 @@ func (c *Client) Trigger(workspaceId string, triggerId string) (*tagmanager.Trig
 }
 
 func (c *Client) UpdateTrigger(workspaceId string, triggerId string, trigger *tagmanager.Trigger) (*tagmanager.Trigger, error) {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Triggers.Update(c.workspacePath(workspaceId)+"/triggers/"+triggerId, trigger).Do()
+	return getResponseWithRetry(c.Accounts.Containers.Workspaces.Triggers.Update(c.workspacePath(workspaceId)+"/triggers/"+triggerId, trigger).Do, c.Options.RetryLimit)
 }
 
 func (c *Client) DeleteTrigger(workspaceId string, triggerId string) error {
-	c.beforeEachQuery()
-	return c.Accounts.Containers.Workspaces.Triggers.Delete(c.workspacePath(workspaceId) + "/triggers/" + triggerId).Do()
+	return executeWithRetry(c.Accounts.Containers.Workspaces.Triggers.Delete(c.workspacePath(workspaceId)+"/triggers/"+triggerId).Do, c.Options.RetryLimit)
+}
+
+// When rate limited, we wait {backoffFactor} seconds for the first retry, {2 * backoffFactor} for the second retry, {3 * backoffFactor} for the third, etc.
+var backoffFactor = time.Duration(20)
+
+func executeWithRetry(query func(opts ...googleapi.CallOption) error, retryLimit int) error {
+	retryCount := 0
+
+	for {
+		err := query()
+		if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 429 {
+			if retryCount < retryLimit {
+				retryCount++
+				backoffDuration := backoffFactor * time.Second * time.Duration(retryCount)
+				fmt.Printf("Rate limited. Retrying in %s...\n", backoffDuration)
+				time.Sleep(backoffDuration)
+				continue
+			} else {
+				return fmt.Errorf("Still rate limited after %d retries", retryLimit)
+			}
+		} else if err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
+}
+
+func getResponseWithRetry[R any](query func(opts ...googleapi.CallOption) (*R, error), retryLimit int) (*R, error) {
+	retryCount := 0
+
+	for {
+		resp, err := query()
+		if errTyped, ok := err.(*googleapi.Error); ok && errTyped.Code == 429 {
+			if retryCount < retryLimit {
+				retryCount++
+				backoffDuration := backoffFactor * time.Second * time.Duration(retryCount)
+				fmt.Printf("Rate limited. Retrying in %s...\n", backoffDuration)
+				time.Sleep(backoffDuration)
+				continue
+			} else {
+				return nil, fmt.Errorf("Still rate limited exceeded after %d retries", retryLimit)
+			}
+		} else if err != nil {
+			return nil, err
+		} else {
+			return resp, nil
+		}
+	}
 }


### PR DESCRIPTION
Not sure if you're maintaining this repo @mirefly, but hopefully you'll see this. It's a useful tool - thanks for creating it!

I'm not having any luck getting a quota increase from Google for the GTM API, so I'm stuck at the 15 requests per minute rate limit. The `max_api_queries_per_minute` method seems like it could be improved on (I can give you a more in depth description of the issues it's causing for me if you'd like).

This alternative method removes the `max_api_queries_per_minute` parameter and adds a `retry_limit` parameter instead. There's no delay before making requests, but if a 429 is received back from the GTM API, we retry with a backoff which increases arithmetically with each subsequent retry, up to the limit.

Cheers!